### PR TITLE
Improve load speed

### DIFF
--- a/src/app/hooks/use-pools-preview.ts
+++ b/src/app/hooks/use-pools-preview.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { ScaledNumber } from "scaled-number";
+import POOL_METADATA from "../../lib/data/pool-metadata";
 import { Optional, Pool } from "../../lib/types";
 
 interface DataResponse {
@@ -13,39 +14,11 @@ interface DataResponse {
   symbol: string;
 }
 
-interface PoolData {
-  id: string;
-  symbol: string;
-}
-
-const POOL_DATA: PoolData[] = [
-  {
-    id: "42cd9ead-de9e-4878-99a1-a984e2ffb4d9",
-    symbol: "FRAX",
-  },
-  {
-    id: "2e9d6ab7-4329-48fd-b962-2ae0e58fc162",
-    symbol: "USDT",
-  },
-  {
-    id: "d9b38ffb-b796-454c-a115-7643fee20f5d",
-    symbol: "ETH",
-  },
-  {
-    id: "65f68bad-18ed-45a7-b089-813780516cdd",
-    symbol: "DAI",
-  },
-  {
-    id: "9078aa8f-7378-4969-925e-567e0c9b8da9",
-    symbol: "USDC",
-  },
-];
-
 const usePoolsPreview = (): Optional<Pool[]> => {
   const [pools, setPools] = useState<Optional<Pool[]>>(null);
 
   const fetchPools = async () => {
-    const queries = POOL_DATA.map(async (data) => {
+    const queries = POOL_METADATA.map(async (data) => {
       const response = await fetch(`https://yields.llama.fi/chart/${data.id}`);
       const json = await response.json();
       return {

--- a/src/app/hooks/use-pools-preview.ts
+++ b/src/app/hooks/use-pools-preview.ts
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { ScaledNumber } from "scaled-number";
+import { Optional, Pool } from "../../lib/types";
+
+interface DataResponse {
+  timestamp: string;
+  tvlUsd: number;
+  apy: number;
+  apyBase: number;
+  apyReward: number;
+  il7d: number;
+  apyBase7d: number;
+  symbol: string;
+}
+
+interface PoolData {
+  id: string;
+  symbol: string;
+}
+
+const POOL_DATA: PoolData[] = [
+  {
+    id: "42cd9ead-de9e-4878-99a1-a984e2ffb4d9",
+    symbol: "FRAX",
+  },
+  {
+    id: "2e9d6ab7-4329-48fd-b962-2ae0e58fc162",
+    symbol: "USDT",
+  },
+  {
+    id: "d9b38ffb-b796-454c-a115-7643fee20f5d",
+    symbol: "ETH",
+  },
+  {
+    id: "65f68bad-18ed-45a7-b089-813780516cdd",
+    symbol: "DAI",
+  },
+  {
+    id: "9078aa8f-7378-4969-925e-567e0c9b8da9",
+    symbol: "USDC",
+  },
+];
+
+const usePoolsPreview = (): Optional<Pool[]> => {
+  const [pools, setPools] = useState<Optional<Pool[]>>(null);
+
+  const fetchPools = async () => {
+    const queries = POOL_DATA.map(async (data) => {
+      const response = await fetch(`https://yields.llama.fi/chart/${data.id}`);
+      const json = await response.json();
+      return {
+        symbol: data.symbol,
+        ...json.data.slice(-1)[0],
+      };
+    });
+    const response = await Promise.all(queries);
+    const pools_: Pool[] = response.map((poolResponse: DataResponse) => {
+      const pool_: Pool = {
+        address: "",
+        apy: ScaledNumber.fromUnscaled(poolResponse.apy / 100),
+        exchangeRate: ScaledNumber.fromUnscaled(1),
+        feeDecreasePeriod: ScaledNumber.fromUnscaled(1),
+        lpToken: {
+          address: "",
+          decimals: 18,
+          name: "",
+          symbol: poolResponse.symbol,
+        },
+        maxWithdrawalFee: ScaledNumber.fromUnscaled(1),
+        minWithdrawalFee: ScaledNumber.fromUnscaled(1),
+        name: "",
+        stakerVaultAddress: "",
+        totalAssets: ScaledNumber.fromUnscaled(poolResponse.tvlUsd),
+        underlying: {
+          address: "",
+          decimals: 18,
+          name: "",
+          symbol: poolResponse.symbol,
+        },
+        harvestable: ScaledNumber.fromUnscaled(1),
+        strategyInfo: null,
+        isPaused: false,
+      };
+      return pool_;
+    });
+    setPools(pools_);
+  };
+
+  useEffect(() => {
+    fetchPools();
+  }, []);
+
+  return pools;
+};
+
+export default usePoolsPreview;

--- a/src/components/Asset.tsx
+++ b/src/components/Asset.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Token } from "../lib/types";
-import poolMetadata from "../lib/data/pool-metadata";
+import POOL_METADATA from "../lib/data/pool-metadata";
 
 const StyledAsset = styled.div`
   display: flex;
@@ -51,11 +51,15 @@ interface Props {
 }
 
 const Asset = ({ token, large, small, tiny, value, hideIcon }: Props): JSX.Element => {
-  const { icon } = poolMetadata[token.symbol];
+  const metadata = POOL_METADATA.find((pool) => pool.symbol === token.symbol);
+
+  if (!metadata) {
+    throw new Error(`No metadata found for ${token.symbol}`);
+  }
 
   return (
     <StyledAsset>
-      {!hideIcon && <Icon src={icon} alt={`${token.symbol} icon`} tiny={tiny} />}
+      {!hideIcon && <Icon src={metadata.icon} alt={`${token.symbol} icon`} tiny={tiny} />}
       <Label large={large} small={small} tiny={tiny}>{`${value || ""}${token.symbol}`}</Label>
     </StyledAsset>
   );

--- a/src/components/Connector.tsx
+++ b/src/components/Connector.tsx
@@ -6,7 +6,6 @@ import { useNavigateToTop } from "../app/hooks/use-navigate-to-top";
 import { useWeb3Updated } from "../app/hooks/use-web3-updated";
 import { AppDispatch } from "../app/store";
 import { injectedConnector } from "../app/web3";
-import { fetchPreviewState } from "../state/poolsListSlice";
 import { isConnecting, setConnecting } from "../state/userSlice";
 import ConnectionDetails from "./ConnectionDetails";
 import ConnectorDesktop from "./ConnectorDesktop";
@@ -32,8 +31,6 @@ const Connector = (): JSX.Element => {
     if (!active) {
       if (authorized) {
         await activate(injectedConnector);
-      } else {
-        dispatch(fetchPreviewState());
       }
     }
   };

--- a/src/lib/data/pool-metadata.ts
+++ b/src/lib/data/pool-metadata.ts
@@ -6,29 +6,41 @@ import dai from "../../assets/tokens/dai.png";
 import usdt from "../../assets/tokens/usdt.png";
 import frax from "../../assets/tokens/frax.png";
 
-interface PoolMetadata {
+export interface PoolMetadata {
   icon: string;
+  id: string;
+  symbol: string;
 }
 
-const poolMetadata: Record<string, PoolMetadata> = {
-  ETH: {
-    icon: eth,
-  },
-  DAI: {
-    icon: dai,
-  },
-  USDC: {
-    icon: usdc,
-  },
-  USDT: {
-    icon: usdt,
-  },
-  FRAX: {
+const POOL_METADATA: PoolMetadata[] = [
+  {
+    id: "42cd9ead-de9e-4878-99a1-a984e2ffb4d9",
+    symbol: "FRAX",
     icon: frax,
   },
-};
+  {
+    id: "2e9d6ab7-4329-48fd-b962-2ae0e58fc162",
+    symbol: "USDT",
+    icon: usdt,
+  },
+  {
+    id: "d9b38ffb-b796-454c-a115-7643fee20f5d",
+    symbol: "ETH",
+    icon: eth,
+  },
+  {
+    id: "65f68bad-18ed-45a7-b089-813780516cdd",
+    symbol: "DAI",
+    icon: dai,
+  },
+  {
+    id: "9078aa8f-7378-4969-925e-567e0c9b8da9",
+    symbol: "USDC",
+    icon: usdc,
+  },
+];
 
-export default poolMetadata;
+export default POOL_METADATA;
 
 export const oldPoolApys: Record<string, ScaledNumber> = {
   "0x2C681E62De119DdCC8bb7E78D7eB92D6C88BcAFe": ScaledNumber.fromUnscaled(0.0966),

--- a/src/pages/landing/Preview.tsx
+++ b/src/pages/landing/Preview.tsx
@@ -1,18 +1,19 @@
 import { useEffect } from "react";
 import styled from "styled-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import PoolsRow from "../pools/PoolsRow";
 import swirls from "../../assets/background/swirls.svg";
 import { useMero } from "../../app/hooks/use-mero";
-import { fetchState, selectPools } from "../../state/poolsListSlice";
+import { fetchState } from "../../state/poolsListSlice";
 import { Pool } from "../../lib";
 import { useWeb3Updated } from "../../app/hooks/use-web3-updated";
 import { Header2, Header4 } from "../../styles/Headers";
 import Loader from "../../components/Loader";
 import { AppDispatch } from "../../app/store";
 import { Optional } from "../../lib/types";
+import usePoolsPreview from "../../app/hooks/use-pools-preview";
 
 const StyledPreview = styled.div`
   position: relative;
@@ -90,7 +91,7 @@ const Preview = (): Optional<JSX.Element> => {
   const { t } = useTranslation();
   const mero = useMero();
   const dispatch = useDispatch<AppDispatch>();
-  const pools = useSelector(selectPools);
+  const pools = usePoolsPreview();
   const updated = useWeb3Updated();
 
   useEffect(() => {

--- a/src/pages/pools/PoolsRow.tsx
+++ b/src/pages/pools/PoolsRow.tsx
@@ -186,16 +186,26 @@ const PoolsRow = ({ pool, preview }: Props): JSX.Element => {
             <Loader />
           )}
         </Data>
-        <Data id={`pool-row-${pool.lpToken.symbol.toLowerCase()}-tvl`} hideOnSnapshot>
-          {price && totalDeposits && totalDeposits.toCompactUsdValue ? (
-            totalDeposits.toCompactUsdValue(price)
-          ) : (
-            <Loader />
-          )}
-        </Data>
-        <DepositedData preview={preview}>
-          {price && deposits ? deposits.toCompactUsdValue(price) : <Loader />}
-        </DepositedData>
+        {preview && (
+          <Data id={`pool-row-${pool.lpToken.symbol.toLowerCase()}-tvl`} hideOnSnapshot>
+            {pool.totalAssets.toCompactUsdValue(1)}
+          </Data>
+        )}
+        {!preview && (
+          <Data id={`pool-row-${pool.lpToken.symbol.toLowerCase()}-tvl`} hideOnSnapshot>
+            {price && totalDeposits && totalDeposits.toCompactUsdValue ? (
+              totalDeposits.toCompactUsdValue(price)
+            ) : (
+              <Loader />
+            )}
+          </Data>
+        )}
+        {!preview && (
+          <DepositedData>
+            {price && deposits ? deposits.toCompactUsdValue(price) : <Loader />}
+          </DepositedData>
+        )}
+
         <ChevronData preview={preview}>
           <Chevron src={chevron} alt="right arrow" />
         </ChevronData>

--- a/src/state/poolsListSlice.ts
+++ b/src/state/poolsListSlice.ts
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { ethers } from "ethers";
 import { ScaledNumber } from "scaled-number";
 
 import { AppThunk, RootState } from "../app/store";
@@ -14,22 +13,15 @@ import {
   Prices,
 } from "../lib/types";
 import { fetchLoans } from "./lendingSlice";
-import { INFURA_ID } from "../lib/constants";
-import { createMero } from "../lib/factory";
-import {
-  fetchActionFees,
-  fetchEstimatedGasUsage,
-  fetchPositions,
-  setPositionsLoaded,
-} from "./positionsSlice";
+import { fetchActionFees, fetchEstimatedGasUsage, fetchPositions } from "./positionsSlice";
 import {
   fetchAllowances,
   fetchBalances,
   fetchGasBankBalance,
   fetchWithdrawalFees,
 } from "./userSlice";
-import poolMetadata from "../lib/data/pool-metadata";
 import { handleTransactionConfirmation } from "../lib/transactionsUtils";
+import POOL_METADATA from "../lib/data/pool-metadata";
 
 interface PoolsState {
   pools: PlainPool[];
@@ -149,17 +141,6 @@ export const fetchState =
     dispatch(fetchGasBankBalance({ mero }));
   };
 
-export const fetchPreviewState = (): AppThunk => (dispatch) => {
-  const provider = new ethers.providers.InfuraProvider(1, INFURA_ID);
-  const mero = createMero(provider, { chainId: 1 });
-  dispatch(fetchOldPools({ mero }));
-  dispatch(fetchPools({ mero })).then((v) => {
-    if (v.meta.requestStatus !== "fulfilled") return;
-    const pools = v.payload as Pool[];
-    dispatch(fetchPrices({ mero, pools }));
-  });
-};
-
 export const selectPoolsLoaded = (state: RootState): boolean => state.pools.loaded;
 
 export const selectPools = (state: RootState): Optional<Pool[]> => {
@@ -167,7 +148,7 @@ export const selectPools = (state: RootState): Optional<Pool[]> => {
   return state.pools.pools
     .map((plainPool: PlainPool) => fromPlainPool(plainPool))
     .filter((pool: Pool) => {
-      if (!poolMetadata[pool.underlying.symbol]) return false;
+      if (!POOL_METADATA.find((m) => m.symbol === pool.underlying.symbol)) return false;
       return true;
     });
 };
@@ -177,7 +158,7 @@ export const selectOldPools = (state: RootState): Optional<Pool[]> => {
   return state.pools.oldPools
     .map((plainPool: PlainPool) => fromPlainPool(plainPool))
     .filter((pool: Pool) => {
-      if (!poolMetadata[pool.underlying.symbol]) return false;
+      if (!POOL_METADATA.find((m) => m.symbol === pool.underlying.symbol)) return false;
       return true;
     });
 };


### PR DESCRIPTION
Currently when a user visits our website with an unconnected wallet, we use Infura to query a 'preview state' to display key data on the landing page such as TVL and Pool Information. There are a few downsides to this approach.

One is that it requires a lot of network requests to load this data. Quite a number of contract views need to be queried, and if any of these fail, then the data on the site will not load, or could show invalid data.

It is also quite slow to load, many of the requests made, rely on another request being made prior to it, and while some are run asynchronously, several need to be chained. For example, we need to query the `AddressProvider` to get a list of pools, then need to query the `LiquidityPool` to get the Vault address, then need to query the `Vault` to get the Strategy address, then need to query the `Strategy` to get the Curve Pool, then need to query the `CurvePool` to get the Curve Underlying Address, then need to query the `CurveUnderlying` to get the Curve Underlying Symbol. This is an extreme example, but there are many such cases.

Also, these Infura RPC requests are not free, and we are needed to maintain a premium plan to support this.

This PR changes to using DeFi Llamas API to query this data. Their API returns the TVL, APYs & USD per pool, which just happens to be everything we need for displaying our landing page. Their API isn't particularly well suited to this, so it's not super clean to query this data, but it is functional. Hopefully in the future we can convince them to create a new API, that is a bit better suited to this.

Some Before and afters:
- Network requests on page load: `739` -> `57`
- Page load time: `4000ms` -> `1500ms`